### PR TITLE
Fix ghcjs cross compile issues

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -5,9 +5,3 @@ constraints:
     ghcjs-base ==0.2.0.3
   , ghcjs-dom ==0.9.5.0
 
-source-repository-package
-  type: git
-  location: https://github.com/peterbecich/ghcjs-base
-  tag: 7a401e982ac64a5720ce9835d0be4ada8ae79995
-  --sha256: 1gb1l0a2zpyp1n47bd3q1lywvk9fpw222pln7c6fq5h65cqb9pbp
-

--- a/ghcjs-example3.cabal
+++ b/ghcjs-example3.cabal
@@ -30,8 +30,10 @@ executable ghcjs-example3
     -- LANGUAGE extensions used by modules in this package.
     -- other-extensions:
     build-depends:    base
-                    , ghcjs-base
                     , ghcjs-dom
-                    , ghcjs-dom-jsffi
     hs-source-dirs:   app
     default-language: Haskell2010
+
+    if os(ghcjs)
+      build-depends:  ghcjs-base
+                    , ghcjs-dom-jsffi

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d1439f976bdbd5202361141302ebe02146781aa4",
-        "sha256": "01dzij9fcsii5qfzbgzhsz277vhxcni960isgxzk8y278h2yj4xv",
+        "rev": "97b3a677898506c3388bb7915602feb720b8d55f",
+        "sha256": "0x8cvbnxsck2blc9kx0z83fzvhq6qww86w4snsd2rcj4q9dqdx2q",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/d1439f976bdbd5202361141302ebe02146781aa4.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/97b3a677898506c3388bb7915602feb720b8d55f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {


### PR DESCRIPTION
`ghcjs-dom` is cross platform (it reexports `ghcjs-dom-jsffi` when compiling for JavaScript or and falls back on the cross platform `jsaddle-dom` otherwise).

`ghcjs-base` and `ghcjs-dom-jsffi` only work when compiling to JavaScript, so they need to be behind an `if os(ghcjs)`.  If you want a cross platform alternative to `ghcjs-base` use `jsaddle`.